### PR TITLE
chore: add Docker dev stack for Pinoox framework core

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+.git
+.github
+.idea
+.vscode
+.DS_Store
+
+# Dependencies (installed at runtime via Composer / npm in mounted tree)
+vendor
+**/node_modules
+
+# Local env
+.env
+.env.local
+.env.*.local
+
+# PHPUnit
+.phpunit.result.cache
+tests
+
+# Runtime data (use Compose volumes)
+pinker
+uploads
+downloads
+
+# macOS / IDE
+*.swp
+*.swo

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env: cp .env.example .env
+#
+# Docker: runtime image = framework infrastructure only (see docker/README.md).
+# Compose project name: pinoox (docker-compose.yml)
+
+APP_PORT=8080
+
+MYSQL_PORT=3307
+MYSQL_DATABASE=pinoox
+MYSQL_USER=pinoox
+MYSQL_PASSWORD=pinoox
+MYSQL_ROOT_PASSWORD=root
+
+# Node.js version for docker/pinoox/Dockerfile (build arg)
+NODE_VERSION=22.12.0

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ pinker
 .idea
 .vscode
 
+# Cursor editor (local rules; see global gitignore)
+.cursor/
+
 # Node Js
 node_modules
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ To get started with Pinoox, follow these steps:
 
 2. Install the required PHP dependencies using Composer: `composer install`
 
+### Docker (optional)
+
+Docker packages **Pinoox core and framework infrastructure** (PHP, Apache, MySQL, Node, Composer) plus the three system apps (installer, manager, welcome). Third-party and market-installed apps are not part of the image. See [docker/README.md](docker/README.md).
+
+```bash
+cp .env.example .env
+docker compose build
+docker compose run --rm pinoox composer install
+docker compose up -d
+```
+
 
 ## Key Features
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+# Pinoox framework.
+# The pinoox image provides PHP, Apache, Node, and Composer only.
+
+name: pinoox
+
+services:
+  pinoox:
+    image: pinoox:dev
+    build:
+      context: .
+      dockerfile: docker/pinoox/Dockerfile
+      args:
+        NODE_VERSION: ${NODE_VERSION:-22.12.0}
+    container_name: pinoox-app
+    ports:
+      - "${APP_PORT:-8080}:80"
+    volumes:
+      # Framework core
+      - ./pincore:/var/www/html/pincore
+      - ./index.php:/var/www/html/index.php
+      - ./bootstrap.php:/var/www/html/bootstrap.php
+      - ./pinoox:/var/www/html/pinoox
+      - ./composer.json:/var/www/html/composer.json
+      - ./.htaccess:/var/www/html/.htaccess
+      # Runtime data (market / user apps, config, uploads)
+      - pinoox_vendor:/var/www/html/vendor
+      - pinoox_pinker:/var/www/html/pinker
+      - pinoox_apps:/var/www/html/apps
+      - pinoox_uploads:/var/www/html/uploads
+      - pinoox_downloads:/var/www/html/downloads
+      # System apps (bind after pinoox_apps so these paths take precedence)
+      - ./apps/com_pinoox_installer:/var/www/html/apps/com_pinoox_installer
+      - ./apps/com_pinoox_manager:/var/www/html/apps/com_pinoox_manager
+      - ./apps/com_pinoox_welcome:/var/www/html/apps/com_pinoox_welcome
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    container_name: pinoox-mysql
+    ports:
+      - "${MYSQL_PORT:-3307}:3306"
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-pinoox}
+      MYSQL_USER: ${MYSQL_USER:-pinoox}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-pinoox}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+    volumes:
+      - pinoox_mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD:-root}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  pinoox_mysql_data:
+  pinoox_vendor:
+  pinoox_pinker:
+  pinoox_apps:
+  pinoox_uploads:
+  pinoox_downloads:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,105 @@
+# Docker — Pinoox framework
+
+Container setup for **Pinoox core and framework infrastructure** only.
+
+## What is included
+
+| Component | Role |
+|-----------|------|
+| **`pinoox:dev` image** | PHP 8.2, Apache, extensions, Node.js, Composer — no application bundle |
+| **`pincore/`** | Framework core (mounted from the repository) |
+| **System apps** | `com_pinoox_installer`, `com_pinoox_manager`, `com_pinoox_welcome` |
+| **`mysql`** | Database for development |
+
+## What is not in the image
+
+- Apps installed later from the **Pinoox market** — stored in the `pinoox_apps` volume under `apps/`
+- Application `vendor/`, `pinker/`, `uploads/`, `downloads/` — persistent Compose volumes
+
+## Requirements
+
+- [Docker Engine](https://docs.docker.com/get-docker/) with [Compose](https://docs.docker.com/compose/) v2
+- The project directory must be readable by the Docker daemon (bind mounts). If you see a “path is not shared” or “mounts denied” error, allow that path in your Docker file-sharing settings or clone the repository to a location your setup already permits. See your platform’s Docker documentation for details.
+
+## Quick start
+
+```bash
+cp .env.example .env
+docker compose build
+docker compose run --rm pinoox composer install
+docker compose up -d
+```
+
+Open **http://localhost:8080** (or `APP_PORT` from `.env`).
+
+### Web installer — database
+
+| Field    | Value                |
+|----------|----------------------|
+| Host     | `mysql`              |
+| Database | `pinoox` (see `.env`) |
+| Username | `pinoox`             |
+| Password | `pinoox`             |
+
+Use the Docker service name **`mysql`**, not `localhost`.
+
+### Writable directories
+
+```bash
+docker compose exec pinoox mkdir -p pinker uploads downloads
+docker compose exec pinoox chown -R www-data:www-data pinker uploads downloads apps
+```
+
+## Commands
+
+```bash
+docker compose exec pinoox bash
+docker compose exec pinoox php pinoox
+docker compose exec pinoox composer install
+```
+
+### Theme builds (system apps)
+
+```bash
+docker compose exec pinoox bash -c "cd apps/com_pinoox_manager/theme/spark && npm ci && npm run build"
+docker compose exec pinoox bash -c "cd apps/com_pinoox_installer/theme/magic && npm ci && npm run build"
+docker compose exec pinoox bash -c "cd apps/com_pinoox_welcome/theme/welcome && npm ci && npm run build"
+```
+
+### After installing an app from the market
+
+If the app ships a `composer.json`, install dependencies inside that app:
+
+```bash
+docker compose exec pinoox bash -c "cd apps/PACKAGE_NAME && composer install --no-dev"
+```
+
+## Host MySQL
+
+| Setting  | Default     |
+|----------|-------------|
+| Host     | `127.0.0.1` |
+| Port     | `3307`      |
+| Database | `pinoox`    |
+| User     | `pinoox`    |
+| Password | `pinoox`    |
+
+## Layout
+
+```
+docker-compose.yml
+docker/pinoox/Dockerfile    # infrastructure image only
+docker/pinoox/apache.conf
+.env.example
+```
+
+**Volumes:** `pinoox_mysql_data`, `pinoox_vendor`, `pinoox_pinker`, `pinoox_apps`, `pinoox_uploads`, `pinoox_downloads`
+
+**Containers:** `pinoox-app`, `pinoox-mysql`
+
+## Troubleshooting
+
+- **Composer** — run `docker compose run --rm pinoox composer install` before first `up` if `vendor/` is missing.
+- **Bind mount denied** — adjust Docker file-sharing for your environment, or clone the repo to a permitted directory.
+- **Database connection** — installer host must be `mysql`.
+- **Permissions** — `docker compose exec pinoox chown -R www-data:www-data pinker uploads downloads apps`

--- a/docker/pinoox/Dockerfile
+++ b/docker/pinoox/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+#
+# Pinoox framework runtime image (infrastructure only).
+# Provides PHP, Apache, extensions, Node.js, and Composer.
+# Does not bundle application code — mount pincore, apps, and project files at runtime.
+
+ARG NODE_VERSION=22.12.0
+
+FROM node:${NODE_VERSION}-bookworm-slim AS node
+
+FROM php:8.2-apache-bookworm
+
+LABEL org.opencontainers.image.title="Pinoox" \
+      org.opencontainers.image.description="Runtime image for the Pinoox PHP framework (core infrastructure only)" \
+      org.opencontainers.image.source="https://github.com/pinoox/pinoox" \
+      org.opencontainers.image.licenses="MIT"
+
+ARG NODE_VERSION=22.12.0
+
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libzip-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libonig-dev \
+        libxml2-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli \
+        pdo_mysql \
+        zip \
+        gd \
+        intl \
+        mbstring \
+        opcache \
+    && a2enmod rewrite \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+COPY docker/pinoox/apache.conf /etc/apache2/sites-available/000-default.conf
+
+WORKDIR /var/www/html
+
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_MEMORY_LIMIT=-1

--- a/docker/pinoox/apache.conf
+++ b/docker/pinoox/apache.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>


### PR DESCRIPTION
## Summary

- Add a Docker Compose dev stack (`name: pinoox`) with PHP 8.2 + Apache, MySQL 8, and Node.js (pinned in `docker/pinoox/Dockerfile`).
- The `pinoox:dev` image provides **framework infrastructure only** (runtime); core code is mounted at dev time (`pincore`, system apps installer/manager/welcome).
- Persistent volumes for `vendor`, `pinker`, market/user `apps`, `uploads`, and `downloads`.
- Document quick start in `docker/README.md` and a short Docker section in the root `README.md`.

## Scope

- **In scope:** Pinoox core + framework infrastructure for local development.
- **Out of scope:** Production deployment, bundling third-party/market apps in the image.

## Test plan

- [ ] `cp .env.example .env`
- [ ] `docker compose build`
- [ ] `docker compose run --rm pinoox composer install`
- [ ] `docker compose up -d`
- [ ] Open http://localhost:8080
- [ ] Complete web installer (DB host: `mysql`)
- [ ] `docker compose exec pinoox php pinoox` runs
- [ ] Prerequisites: PHP, mod_rewrite, MySQL pass